### PR TITLE
Replace PathMultiPiece instances with a more generic one.

### DIFF
--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -63,17 +63,9 @@ class PathMultiPiece s where
     fromPathMultiPiece :: [S.Text] -> Maybe s
     toPathMultiPiece :: s -> [S.Text]
 
-instance PathMultiPiece [String] where
-    fromPathMultiPiece = Just . map S.unpack
-    toPathMultiPiece = map S.pack
-
-instance PathMultiPiece [S.Text] where
-    fromPathMultiPiece = Just
-    toPathMultiPiece = id
-
-instance PathMultiPiece [L.Text] where
-    fromPathMultiPiece = Just . map (L.fromChunks . return)
-    toPathMultiPiece = map $ S.concat . L.toChunks
+instance PathPiece p => PathMultiPiece [p] where
+    fromPathMultiPiece = sequence . map fromPathPiece   -- (in the Maybe monad)
+    toPathMultiPiece = map toPathPiece
 
 {-# DEPRECATED toSinglePiece "Use toPathPiece instead of toSinglePiece" #-}
 toSinglePiece :: PathPiece p => p -> S.Text

--- a/path-pieces.cabal
+++ b/path-pieces.cabal
@@ -1,5 +1,5 @@
 name:            path-pieces
-version:         0.1.2
+version:         0.1.3
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -17,7 +17,7 @@ library
                    , text             >= 0.5     && < 0.12
                    , time
     exposed-modules: Web.PathPieces
-    ghc-options:     -Wall
+    ghc-options:     -Wall -O2
 
 test-suite test
     type:          exitcode-stdio-1.0
@@ -31,6 +31,7 @@ test-suite test
                    , QuickCheck
                    , path-pieces
                    , text
+                   , time
 
 source-repository head
   type:     git

--- a/test/main.hs
+++ b/test/main.hs
@@ -7,14 +7,18 @@ import Test.Hspec.QuickCheck(prop)
 import Test.QuickCheck
 
 import Web.PathPieces
+import Data.Int (Int64)
 import qualified Data.Text as T
 import Data.Maybe (fromJust)
+import Data.Time (Day(..))
 
 -- import FileLocation (debug)
 
 instance Arbitrary T.Text where
   arbitrary = fmap T.pack arbitrary
 
+instance Arbitrary Day where
+  arbitrary = fmap ModifiedJulianDay arbitrary
 
 main :: IO ()
 main = hspec spec
@@ -42,6 +46,24 @@ spec = do
       p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
 
     prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[T.Text]) ->
+      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
+
+    prop "toPathMultiPiece <=> fromPathMultiPiece Integer" $ \(p::[Integer]) ->
+      case (fromPathMultiPiece . toPathMultiPiece) p of
+        Nothing -> any (< 0) p
+        Just pConverted -> p == pConverted
+
+    prop "toPathMultiPiece <=> fromPathMultiPiece Int" $ \(p::[Int]) ->
+      case (fromPathMultiPiece . toPathMultiPiece) p of
+        Nothing -> any (< 0) p
+        Just pConverted -> p == pConverted
+
+    prop "toPathMultiPiece <=> fromPathMultiPiece Int64" $ \(p::[Int64]) ->
+      case (fromPathMultiPiece . toPathMultiPiece) p of
+        Nothing -> any (< 0) p
+        Just pConverted -> p == pConverted
+
+    prop "toPathMultiPiece <=> fromPathMultiPiece Day" $ \(p::[Day]) ->
       p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
 
 


### PR DESCRIPTION
In my present project, I came across a need for an instance of `PathMultiPiece` for `[Int]`.  Pretty trivial, but GHC gave me the "orphan instance" annoyance, and anyway I had written the instance methods in a completely generic fashion.

This change puts the generic implementation into the `Web.PathPieces` library, automatically providing `instance PathPiece p => PathMultiPiece [p]`.

NB I have taken the liberty of bumping the version in the cabal file, as this seems to be the only change for a while.

At the moment I have _replaced_ the specific instances with the general one.  There is a small performance penalty in doing this.  In percentage terms, the strict Text case is the most affected, since its special-case implementation is so trivial - the generic implementation is about half the speed, as judged by mapping a test function containing just a check of `fromPathMultiPiece . toPathMultiPiece` over a pre-evaluated list of a million examples.

It would, of course, be possible to retain the special case for `[Text]` and use `OverlappingInstances`, but I didn't think the performance difference was likely to be important in a realistic situation.  However, I do not have a sensible benchmark setup for a whole application, so I have not checked that assertion.
