### PR TITLE
Use http-api-data package

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,17 @@
+## Unreleased changes
+
+* Use `http-api-data` package as a source for `PathPiece` instances
+* Add new `PathPiece` instances:
+    * `Char`
+    * `Ordering`
+    * `Double`, `Float`
+    * `()`, `Void`
+    * `Version`
+    * `All`, `Any`, `Dual a`, `Sum a`, `Product a`, `First a`, `Last a`
+    * `Either a b`
+* Make `PathPiece` instances encoded in lower case and decoded case-insensitively
+* Add `Web.PathPiece.Internal` module
+
 ## 0.2.0
 
 * Make `PathMultiPiece` instance for lists based on `PathPiece` [Yesod issue #932](https://github.com/yesodweb/yesod/issues/932)

--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -1,167 +1,18 @@
-{-# LANGUAGE FlexibleInstances, TypeSynonymInstances, OverloadedStrings #-}
-module Web.PathPieces
-    ( PathPiece (..)
-    , PathMultiPiece (..)
-    , readFromPathPiece
-    , showToPathPiece
-    -- * Deprecated
-    , toSinglePiece
-    , toMultiPiece
-    , fromSinglePiece
-    , fromMultiPiece
-    ) where
+-- |
+-- Convert Haskell values to and from route pieces.
+module Web.PathPieces (
+  PathPiece (..),
+  PathMultiPiece (..),
 
-import Data.Int (Int8, Int16, Int32, Int64)
-import Data.Word (Word, Word8, Word16, Word32, Word64)
-import qualified Data.Text as S
-import qualified Data.Text.Lazy as L
-import qualified Data.Text.Read
-import Data.Time (Day)
-import Control.Exception (assert)
-import Text.Read (readMaybe)
+  readFromPathPiece,
+  showToPathPiece,
 
-class PathPiece s where
-    fromPathPiece :: S.Text -> Maybe s
-    toPathPiece :: s -> S.Text
+  -- * Deprecated
+  toSinglePiece,
+  toMultiPiece,
+  fromSinglePiece,
+  fromMultiPiece,
+) where
 
-instance PathPiece () where
-    fromPathPiece t = if t == "_" then Just () else Nothing
-    toPathPiece () = "_"
+import Web.PathPieces.Internal
 
-instance PathPiece String where
-    fromPathPiece = Just . S.unpack
-    toPathPiece = S.pack
-
-instance PathPiece S.Text where
-    fromPathPiece = Just
-    toPathPiece = id
-
-instance PathPiece L.Text where
-    fromPathPiece = Just . L.fromChunks . return
-    toPathPiece = S.concat . L.toChunks
-
-parseIntegral :: (Integral a, Bounded a, Ord a) => S.Text -> Maybe a
-parseIntegral s = n
-    where
-    n = case Data.Text.Read.signed Data.Text.Read.decimal s of
-        Right (i, "") | i <= top && i >= bot -> Just (fromInteger i)
-        _ -> Nothing
-    Just witness = n
-    top = toInteger (maxBound `asTypeOf` witness)
-    bot = toInteger (minBound `asTypeOf` witness)
-
-instance PathPiece Integer where
-    fromPathPiece s =
-        case Data.Text.Read.signed Data.Text.Read.decimal s of
-            Right (i, "") -> Just i
-            _ -> Nothing
-    toPathPiece = S.pack . show
-
-instance PathPiece Int where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Int8 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Int16 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Int32 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Int64 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Word where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Word8 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Word16 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Word32 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Word64 where
-    fromPathPiece = parseIntegral
-    toPathPiece = S.pack . show
-
-instance PathPiece Bool where
-    fromPathPiece t =
-        case filter (null . snd) $ reads $ S.unpack t of
-            (a, s):_ -> assert (null s) (Just a)
-            _        -> Nothing
-    toPathPiece = S.pack . show
-
-instance PathPiece Day where
-    fromPathPiece t =
-        case reads $ S.unpack t of
-            [(a,"")] -> Just a
-            _ -> Nothing
-    toPathPiece = S.pack . show
-
-instance (PathPiece a) => PathPiece (Maybe a) where
-    fromPathPiece s = case S.stripPrefix "Just " s of
-        Just r -> Just `fmap` fromPathPiece r
-        _ -> case s of
-            "Nothing" -> Just Nothing
-            _ -> Nothing
-    toPathPiece m = case m of
-        Just s -> "Just " `S.append` toPathPiece s
-        _ -> "Nothing"
-
-class PathMultiPiece s where
-    fromPathMultiPiece :: [S.Text] -> Maybe s
-    toPathMultiPiece :: s -> [S.Text]
-
-instance PathPiece a => PathMultiPiece [a] where
-    fromPathMultiPiece = mapM fromPathPiece
-    toPathMultiPiece = map toPathPiece
-
--- | A function for helping generate free 'PathPiece'
---   instances for enumeration data types 
---   that have derived 'Read' and 'Show' instances.
---   Intended to be used like this:
---
---   > data MyData = Foo | Bar | Baz
---   >   deriving (Read,Show)
---   > instance PathPiece MyData where
---   >   fromPathPiece = readFromPathPiece
---   >   toPathPiece = showToPathPiece
---
---  Since 0.2.1. 
-readFromPathPiece :: Read s => S.Text -> Maybe s
-readFromPathPiece = readMaybe . S.unpack
-
--- | See the documentation for 'readFromPathPiece'.
---
---  Since 0.2.1. 
-showToPathPiece :: Show s => s -> S.Text
-showToPathPiece = S.pack . show
-
-{-# DEPRECATED toSinglePiece "Use toPathPiece instead of toSinglePiece" #-}
-toSinglePiece :: PathPiece p => p -> S.Text
-toSinglePiece = toPathPiece
-
-{-# DEPRECATED fromSinglePiece "Use fromPathPiece instead of fromSinglePiece" #-}
-fromSinglePiece :: PathPiece p => S.Text -> Maybe p
-fromSinglePiece = fromPathPiece
-
-{-# DEPRECATED toMultiPiece "Use toPathMultiPiece instead of toMultiPiece" #-}
-toMultiPiece :: PathMultiPiece ps => ps -> [S.Text]
-toMultiPiece = toPathMultiPiece
-
-{-# DEPRECATED fromMultiPiece "Use fromPathMultiPiece instead of fromMultiPiece" #-}
-fromMultiPiece :: PathMultiPiece ps => [S.Text] -> Maybe ps
-fromMultiPiece = fromPathMultiPiece

--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -1,9 +1,14 @@
 -- |
 -- Convert Haskell values to and from route pieces.
 module Web.PathPieces (
+  -- * Examples
+  -- $examples
+
+  -- * Classes
   PathPiece (..),
   PathMultiPiece (..),
 
+  -- * Helpers
   readFromPathPiece,
   showToPathPiece,
 
@@ -16,3 +21,46 @@ module Web.PathPieces (
 
 import Web.PathPieces.Internal
 
+-- $setup
+--
+-- >>> :set -XOverloadedStrings
+-- >>> import Control.Applicative
+-- >>> import Data.Time
+-- >>> import Data.Int
+-- >>> import Data.Text (Text)
+-- >>> import Data.Time (Day)
+-- >>> import Data.Version
+
+-- $examples
+--
+-- Booleans:
+--
+-- >>> toPathPiece True
+-- "true"
+-- >>> fromPathPiece "false" :: Maybe Bool
+-- Just False
+-- >>> fromPathPiece "something else" :: Maybe Bool
+-- Nothing
+--
+-- Numbers:
+--
+-- >>> toPathPiece 45.2
+-- "45.2"
+-- >>> fromPathPiece "452" :: Maybe Int
+-- Just 452
+-- >>> fromPathPiece "256" :: Maybe Int8
+-- Nothing
+--
+-- Strings:
+--
+-- >>> toPathPiece "hello"
+-- "hello"
+-- >>> fromPathPiece "world" :: Maybe String
+-- Just "world"
+--
+-- Calendar day:
+--
+-- >>> toPathPiece (fromGregorian 2015 10 03)
+-- "2015-10-03"
+-- >>> toGregorian <$> fromPathPiece "2016-12-01"
+-- Just (2016,12,1)

--- a/Web/PathPieces/Internal.hs
+++ b/Web/PathPieces/Internal.hs
@@ -30,16 +30,24 @@ import Web.HttpApiData.Internal (parseMaybeTextData, parseUrlPieceMaybe)
 -- | Convert Haskell values to and from route piece.
 class PathPiece s where
   -- | Convert from route piece.
+  --
+  -- Default implementation relies on @'FromHttpApiData'@ instance.
   fromPathPiece :: S.Text -> Maybe s
   default fromPathPiece :: FromHttpApiData s => S.Text -> Maybe s
   fromPathPiece = defaultFromPathPiece
 
   -- | Convert to route piece.
+  --
+  -- Default implementation relies on @'ToHttpApiData'@ instance.
   toPathPiece :: s -> S.Text
   default toPathPiece :: ToHttpApiData s => s -> S.Text
   toPathPiece = defaultToPathPiece
 
+-- |
+-- >>> toPathPiece ()
+-- "_"
 instance PathPiece ()
+
 instance PathPiece Char
 instance PathPiece Bool
 instance PathPiece Ordering
@@ -89,10 +97,20 @@ instance PathPiece a => PathPiece (Last a) where
   toPathPiece   = defaultToPathPiece1
   fromPathPiece = defaultFromPathPiece1
 
+-- |
+-- >>> toPathPiece (Just "Hello")
+-- "just Hello"
+-- >>> fromPathPiece "JUST 123" :: Maybe (Maybe Int)
+-- Just (Just 123)
 instance PathPiece a => PathPiece (Maybe a) where
   toPathPiece   = defaultToPathPiece1
   fromPathPiece = defaultFromPathPiece1
 
+-- |
+-- >>> toPathPiece (Left "err" :: Either String Int)
+-- "left err"
+-- >>> fromPathPiece "Right 123" :: Maybe (Either String Int)
+-- Just (Right 123)
 instance (PathPiece a, PathPiece b) => PathPiece (Either a b) where
   toPathPiece   = defaultToPathPiece2
   fromPathPiece = defaultFromPathPiece2

--- a/Web/PathPieces/Internal.hs
+++ b/Web/PathPieces/Internal.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+-- |
+-- Convert Haskell values to and from route pieces.
+module Web.PathPieces.Internal where
+
+import Data.Monoid
+import Data.Int
+import Data.Word
+import qualified Data.Text as S
+import qualified Data.Text.Lazy as L
+import Data.Version (Version)
+import Data.Time (Day)
+import Text.Read (readMaybe)
+
+import Unsafe.Coerce
+
+#if MIN_VERSION_base(4,8,0)
+import Data.Void (Void)
+#endif
+
+import Web.HttpApiData
+import Web.HttpApiData.Internal (parseMaybeTextData, parseUrlPieceMaybe)
+
+-- | Convert Haskell values to and from route piece.
+class PathPiece s where
+  -- | Convert from route piece.
+  fromPathPiece :: S.Text -> Maybe s
+  default fromPathPiece :: FromHttpApiData s => S.Text -> Maybe s
+  fromPathPiece = defaultFromPathPiece
+
+  -- | Convert to route piece.
+  toPathPiece :: s -> S.Text
+  default toPathPiece :: ToHttpApiData s => s -> S.Text
+  toPathPiece = defaultToPathPiece
+
+instance PathPiece ()
+instance PathPiece Char
+instance PathPiece Bool
+instance PathPiece Ordering
+instance PathPiece Double
+instance PathPiece Float
+instance PathPiece Int
+instance PathPiece Int8
+instance PathPiece Int16
+instance PathPiece Int32
+instance PathPiece Int64
+instance PathPiece Integer
+instance PathPiece Word
+instance PathPiece Word8
+instance PathPiece Word16
+instance PathPiece Word32
+instance PathPiece Word64
+instance PathPiece String
+instance PathPiece S.Text
+instance PathPiece L.Text
+instance PathPiece Day
+instance PathPiece Version
+
+#if MIN_VERSION_base(4,8,0)
+instance PathPiece Void
+#endif
+
+instance PathPiece All
+instance PathPiece Any
+
+instance PathPiece a => PathPiece (Dual a) where
+  toPathPiece   = defaultToPathPiece1
+  fromPathPiece = defaultFromPathPiece1
+
+instance PathPiece a => PathPiece (Sum a) where
+  toPathPiece   = defaultToPathPiece1
+  fromPathPiece = defaultFromPathPiece1
+
+instance PathPiece a => PathPiece (Product a) where
+  toPathPiece   = defaultToPathPiece1
+  fromPathPiece = defaultFromPathPiece1
+
+instance PathPiece a => PathPiece (First a) where
+  toPathPiece   = defaultToPathPiece1
+  fromPathPiece = defaultFromPathPiece1
+
+instance PathPiece a => PathPiece (Last a) where
+  toPathPiece   = defaultToPathPiece1
+  fromPathPiece = defaultFromPathPiece1
+
+instance PathPiece a => PathPiece (Maybe a) where
+  toPathPiece   = defaultToPathPiece1
+  fromPathPiece = defaultFromPathPiece1
+
+instance (PathPiece a, PathPiece b) => PathPiece (Either a b) where
+  toPathPiece   = defaultToPathPiece2
+  fromPathPiece = defaultFromPathPiece2
+
+-- | Wrapped @'PathPiece'@ value.
+newtype WrappedPathPiece a = WrappedPathPiece { unwrapPathPiece :: a }
+
+instance PathPiece a => ToHttpApiData (WrappedPathPiece a) where
+  toUrlPiece = toPathPiece . unwrapPathPiece
+
+instance PathPiece a => FromHttpApiData (WrappedPathPiece a) where
+  parseUrlPiece = fmap WrappedPathPiece . parseMaybeTextData fromPathPiece
+
+-- | Convert value to route piece using @'ToHttpApiData'@ implementation.
+defaultToPathPiece :: ToHttpApiData a => a -> S.Text
+defaultToPathPiece = toUrlPiece
+
+-- | Convert value from route piece using @'FromHttpApiData'@ implementation.
+defaultFromPathPiece :: FromHttpApiData a => S.Text -> Maybe a
+defaultFromPathPiece = parseUrlPieceMaybe
+
+-- | Convert value to route piece using @'PathPiece'@ instance for its parameter.
+defaultToPathPiece1 :: (PathPiece a, ToHttpApiData (f (WrappedPathPiece a))) => f a -> S.Text
+defaultToPathPiece1 = toUrlPiece . (unsafeCoerce :: f a -> f (WrappedPathPiece a))
+
+-- | Parse value from route piece using @'PathPiece'@ instance for its parameter.
+defaultFromPathPiece1 :: (PathPiece a, FromHttpApiData (f (WrappedPathPiece a))) => S.Text -> Maybe (f a)
+defaultFromPathPiece1 = fmap (unsafeCoerce :: f (WrappedPathPiece a) -> f a) . defaultFromPathPiece
+
+-- | Convert value to route piece using @'PathPiece'@ instance for its parameters.
+defaultToPathPiece2 :: (PathPiece a, PathPiece b, ToHttpApiData (f (WrappedPathPiece a) (WrappedPathPiece b))) => f a b -> S.Text
+defaultToPathPiece2 = toUrlPiece . (unsafeCoerce :: f a b -> f (WrappedPathPiece a) (WrappedPathPiece b))
+
+-- | Parse value from route piece using @'PathPiece'@ instance for its parameters.
+defaultFromPathPiece2 :: (PathPiece a, PathPiece b, FromHttpApiData (f (WrappedPathPiece a) (WrappedPathPiece b))) => S.Text -> Maybe (f a b)
+defaultFromPathPiece2 = fmap (unsafeCoerce :: f (WrappedPathPiece a) (WrappedPathPiece b) -> f a b) . defaultFromPathPiece
+
+-- | Convert Haskell values to and from sequence of route pieces.
+class PathMultiPiece s where
+  -- | Convert from sequence of route pieces.
+  fromPathMultiPiece :: [S.Text] -> Maybe s
+  -- | Convert to sequence of route pieces.
+  toPathMultiPiece :: s -> [S.Text]
+
+instance PathPiece a => PathMultiPiece [a] where
+    fromPathMultiPiece = mapM fromPathPiece
+    toPathMultiPiece = map toPathPiece
+
+-- | A function for helping generate free 'PathPiece'
+--   instances for enumeration data types 
+--   that have derived 'Read' and 'Show' instances.
+--   Intended to be used like this:
+--
+--   > data MyData = Foo | Bar | Baz
+--   >   deriving (Read,Show)
+--   > instance PathPiece MyData where
+--   >   fromPathPiece = readFromPathPiece
+--   >   toPathPiece = showToPathPiece
+--
+--  Since 0.2.1.
+readFromPathPiece :: Read s => S.Text -> Maybe s
+readFromPathPiece = readMaybe . S.unpack
+
+-- | See the documentation for 'readFromPathPiece'.
+--
+--  Since 0.2.1.
+showToPathPiece :: Show s => s -> S.Text
+showToPathPiece = S.pack . show
+
+{-# DEPRECATED toSinglePiece "Use toPathPiece instead of toSinglePiece" #-}
+toSinglePiece :: PathPiece p => p -> S.Text
+toSinglePiece = toPathPiece
+
+{-# DEPRECATED fromSinglePiece "Use fromPathPiece instead of fromSinglePiece" #-}
+fromSinglePiece :: PathPiece p => S.Text -> Maybe p
+fromSinglePiece = fromPathPiece
+
+{-# DEPRECATED toMultiPiece "Use toPathMultiPiece instead of toMultiPiece" #-}
+toMultiPiece :: PathMultiPiece ps => ps -> [S.Text]
+toMultiPiece = toPathMultiPiece
+
+{-# DEPRECATED fromMultiPiece "Use fromPathMultiPiece instead of fromMultiPiece" #-}
+fromMultiPiece :: PathMultiPiece ps => [S.Text] -> Maybe ps
+fromMultiPiece = fromPathMultiPiece

--- a/path-pieces.cabal
+++ b/path-pieces.cabal
@@ -19,7 +19,10 @@ library
     build-depends:   base             >= 4       && < 5
                    , text             >= 0.5
                    , time
-    exposed-modules: Web.PathPieces
+                   , http-api-data
+    exposed-modules:
+      Web.PathPieces
+      Web.PathPieces.Internal
     ghc-options:     -Wall
 
 test-suite test
@@ -33,6 +36,7 @@ test-suite test
                    , QuickCheck
                    , path-pieces
                    , text
+                   , time
 
 source-repository head
   type:     git

--- a/path-pieces.cabal
+++ b/path-pieces.cabal
@@ -38,6 +38,12 @@ test-suite test
                    , text
                    , time
 
+test-suite doctest
+    build-depends:    base, doctest, Glob
+    hs-source-dirs:   test
+    main-is:          DocTest.hs
+    type:             exitcode-stdio-1.0
+
 source-repository head
   type:     git
   location: https://github.com/yesodweb/path-pieces

--- a/test/DocTest.hs
+++ b/test/DocTest.hs
@@ -1,0 +1,7 @@
+module Main (main) where
+
+import System.FilePath.Glob (glob)
+import Test.DocTest (doctest)
+
+main :: IO ()
+main = glob "Web/**/*.hs" >>= doctest

--- a/test/main.hs
+++ b/test/main.hs
@@ -2,81 +2,109 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Main where
 
+import Control.Applicative
+
+import Data.Int
+import Data.Char
+import Data.Word
+import Data.Time
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as L
+import Data.Version
+
 import Test.Hspec
 import Test.Hspec.QuickCheck(prop)
 import Test.QuickCheck
 
 import Web.PathPieces
-import qualified Data.Text as T
-import Data.Maybe (fromJust)
-
--- import FileLocation (debug)
 
 instance Arbitrary T.Text where
-  arbitrary = fmap T.pack arbitrary
+  arbitrary = T.pack <$> arbitrary
 
+instance Arbitrary L.Text where
+  arbitrary = L.pack <$> arbitrary
+
+instance Arbitrary Day where
+  arbitrary = liftA3 fromGregorian (fmap abs arbitrary) arbitrary arbitrary
+
+instance Arbitrary Version where
+  arbitrary = (version . map abs) <$> nonempty
+    where
+      version branch = Version branch []
+      nonempty = liftA2 (:) arbitrary arbitrary
 
 main :: IO ()
 main = hspec spec
 
+(<=>) :: Eq a => (a -> b) -> (b -> Maybe a) -> a -> Bool
+(f <=> g) x = g (f x) == Just x
+
+data Proxy a = Proxy
+
+checkPathPiece :: forall a. (Eq a, PathPiece a, Show a, Arbitrary a) => Proxy a -> String -> Spec
+checkPathPiece _ name = prop ("toPathPiece <=> fromPathPiece " ++ name) (toPathPiece <=> fromPathPiece :: a -> Bool)
+
+checkPathMultiPiece :: forall a. (Eq a, PathMultiPiece a, Show a, Arbitrary a) => Proxy a -> String -> Spec
+checkPathMultiPiece _ name = prop ("toPathMultiPiece <=> fromPathMultiPiece " ++ name) (toPathMultiPiece <=> fromPathMultiPiece :: a -> Bool)
+
+data RandomCase a = RandomCase [Bool] a
+
+instance PathPiece a => Show (RandomCase a) where
+  show rc@(RandomCase _ x) = show (toPathPiece rc) ++ " (original: " ++ show (toPathPiece x) ++ ")"
+
+instance Eq a => Eq (RandomCase a) where
+  RandomCase _ x == RandomCase _ y = x == y
+
+instance Arbitrary a => Arbitrary (RandomCase a) where
+  arbitrary = liftA2 RandomCase nonempty arbitrary
+    where
+      nonempty = liftA2 (:) arbitrary arbitrary
+
+instance PathPiece a => PathPiece (RandomCase a) where
+  toPathPiece (RandomCase us x) = T.pack (zipWith (\u -> if u then toUpper else toLower) (cycle us) (T.unpack (toPathPiece x)))
+  fromPathPiece s = RandomCase [] <$> fromPathPiece s
+
+-- | Check case insensitivity for @fromPathPiece@.
+checkPathPieceI :: forall a. (Eq a, PathPiece a, Show a, Arbitrary a) => Proxy a -> String -> Spec
+checkPathPieceI _ = checkPathPiece (Proxy :: Proxy (RandomCase a))
+
 spec :: Spec
 spec = do
   describe "PathPiece" $ do
-    prop "toPathPiece <=> fromPathPiece String" $ \(p::String) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> null p
-        Just pConverted -> p == pConverted
+    checkPathPiece  (Proxy :: Proxy ())        "()"
+    checkPathPiece  (Proxy :: Proxy Char)      "Char"
+    checkPathPieceI (Proxy :: Proxy Bool)      "Bool"
+    checkPathPieceI (Proxy :: Proxy Ordering)  "Ordering"
+    checkPathPiece  (Proxy :: Proxy Int)       "Int"
+    checkPathPiece  (Proxy :: Proxy Int8)      "Int8"
+    checkPathPiece  (Proxy :: Proxy Int16)     "Int16"
+    checkPathPiece  (Proxy :: Proxy Int32)     "Int32"
+    checkPathPiece  (Proxy :: Proxy Int64)     "Int64"
+    checkPathPiece  (Proxy :: Proxy Integer)   "Integer"
+    checkPathPiece  (Proxy :: Proxy Word)      "Word"
+    checkPathPiece  (Proxy :: Proxy Word8)     "Word8"
+    checkPathPiece  (Proxy :: Proxy Word16)    "Word16"
+    checkPathPiece  (Proxy :: Proxy Word32)    "Word32"
+    checkPathPiece  (Proxy :: Proxy Word64)    "Word64"
+    checkPathPiece  (Proxy :: Proxy String)    "String"
+    checkPathPiece  (Proxy :: Proxy T.Text)    "Text.Strict"
+    checkPathPiece  (Proxy :: Proxy L.Text)    "Text.Lazy"
+    checkPathPiece  (Proxy :: Proxy Day)       "Day"
+    checkPathPiece  (Proxy :: Proxy Version)   "Version"
 
-    prop "toPathPiece <=> fromPathPiece Text" $ \(p::T.Text) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> T.null p
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Int" $ \(p::Int) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> False
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Bool" $ \(p::Bool) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> False
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Maybe String" $ \(p::Maybe String) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> False
-        Just pConverted -> p == pConverted
+    checkPathPiece  (Proxy :: Proxy (Maybe String))            "Maybe String"
+    checkPathPieceI (Proxy :: Proxy (Maybe Integer))           "Maybe Integer"
+    checkPathPiece  (Proxy :: Proxy (Either Integer T.Text))   "Either Integer Text"
+    checkPathPieceI (Proxy :: Proxy (Either Version Day))      "Either Version Day"
 
   describe "PathMultiPiece" $ do
-    prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[String]) ->
-      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
+    checkPathMultiPiece (Proxy :: Proxy [String])   "[String]"
+    checkPathMultiPiece (Proxy :: Proxy [T.Text])   "[Text]"
 
-    prop "toPathMultiPiece <=> fromPathMultiPiece Text" $ \(p::[T.Text]) ->
-      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
+  it "bad integers are rejected" $ do
+    fromPathPiece (T.pack "123hello") `shouldBe` (Nothing :: Maybe Int)
 
+  it "bounds checking works" $ do
+    fromPathPiece (T.pack "256") `shouldBe` (Nothing :: Maybe Int8)
+    fromPathPiece (T.pack "-10") `shouldBe` (Nothing :: Maybe Word)
 
-  describe "SinglePiece" $ do
-    prop "toPathPiece <=> fromPathPiece String" $ \(p::String) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> null p
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Text" $ \(p::T.Text) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> T.null p
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Int" $ \(p::Int) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> p < 0
-        Just pConverted -> p == pConverted
-
-  describe "MultiPiece" $ do
-    prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[String]) ->
-      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
-
-    prop "toPathMultiPiece <=> fromPathMultiPiece Text" $ \(p::[T.Text]) ->
-      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
-
-  it "bad ints are rejected" $ fromPathPiece (T.pack "123hello")
-    `shouldBe` (Nothing :: Maybe Int)


### PR DESCRIPTION
Changes:
* Use `http-api-data` package as a source for `PathPiece` instances
* Make `PathPiece` instances encoded in lower case and decoded case-insensitively
* Add `Web.PathPiece.Internal` module
* Add new `PathPiece` instances:
    * `Char`
    * `Ordering`
    * `Double`, `Float`
    * `Void`
    * `Version`
    * `All`, `Any`, `Dual a`, `Sum a`, `Product a`, `First a`, `Last a`
    * `Either a b`

Also added some documentation and `doctest` test suite.

I would also like to remove deprecated and unreleased helpers, but need your approval first.