### PR TITLE
Text.Read.readMaybe is only present in base >= 4.6

### DIFF
--- a/path-pieces.cabal
+++ b/path-pieces.cabal
@@ -16,7 +16,7 @@ extra-source-files:
   README.md
 
 library
-    build-depends:   base             >= 4       && < 5
+    build-depends:   base             >= 4.6     && < 5
                    , text             >= 0.5
                    , time
     exposed-modules: Web.PathPieces


### PR DESCRIPTION
Only applies to the latest version, my revision: http://hackage.haskell.org/package/path-pieces-0.2.1/revisions/
