### PR TITLE
Remove duplicate tests

### DIFF
--- a/test/main.hs
+++ b/test/main.hs
@@ -54,29 +54,5 @@ spec = do
     prop "toPathMultiPiece <=> fromPathMultiPiece Text" $ \(p::[T.Text]) ->
       p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
 
-
-  describe "SinglePiece" $ do
-    prop "toPathPiece <=> fromPathPiece String" $ \(p::String) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> null p
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Text" $ \(p::T.Text) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> T.null p
-        Just pConverted -> p == pConverted
-
-    prop "toPathPiece <=> fromPathPiece Int" $ \(p::Int) ->
-      case (fromPathPiece . toPathPiece) p of
-        Nothing -> False
-        Just pConverted -> p == pConverted
-
-  describe "MultiPiece" $ do
-    prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[String]) ->
-      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
-
-    prop "toPathMultiPiece <=> fromPathMultiPiece Text" $ \(p::[T.Text]) ->
-      p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p
-
   it "bad ints are rejected" $ fromPathPiece (T.pack "123hello")
     `shouldBe` (Nothing :: Maybe Int)

--- a/test/main.hs
+++ b/test/main.hs
@@ -68,7 +68,7 @@ spec = do
 
     prop "toPathPiece <=> fromPathPiece Int" $ \(p::Int) ->
       case (fromPathPiece . toPathPiece) p of
-        Nothing -> p < 0
+        Nothing -> False
         Just pConverted -> p == pConverted
 
   describe "MultiPiece" $ do


### PR DESCRIPTION
Most tests are duplicated on `test/main.hs`, see:

```
describe "PathPiece" $ do
   prop "toPathPiece <=> fromPathPiece String" $ \(p::String) ->
     case (fromPathPiece . toPathPiece) p of
       Nothing -> null p
       Just pConverted -> p == pConverted
...
...
...
describe "SinglePiece" $ do
   prop "toPathPiece <=> fromPathPiece String" $ \(p::String) ->
     case (fromPathPiece . toPathPiece) p of
       Nothing -> null p
       Just pConverted -> p == pConverted
```

This removes all duplicate tests.