### PR TITLE
Add PathPiece (Either a b) instance.

### DIFF
--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -181,6 +181,15 @@ instance (PathPiece a) => PathPiece (Maybe a) where
         Just s -> "Just " `S.append` toPathPiece s
         _ -> "Nothing"
 
+instance (PathPiece a, PathPiece b) => PathPiece (Either a b) where
+    fromPathPiece s = case (S.stripPrefix "Left " s, S.stripPrefix "Right " s) of
+        (_, Just r) -> Right `fmap` fromPathPiece r
+        (Just l, _) -> Left  `fmap` fromPathPiece l
+        (_, _)      -> Nothing
+    toPathPiece m = case m of
+        Right s -> "Right " `S.append` toPathPiece s
+        Left  s -> "Left "  `S.append` toPathPiece s
+
 -- | Instances of the 'PathMultiPiece' typeclass can be converted to and from
 --   several "path pieces" of URLs.
 --

--- a/test/main.hs
+++ b/test/main.hs
@@ -47,6 +47,11 @@ spec = do
         Nothing -> False
         Just pConverted -> p == pConverted
 
+    prop "toPathPiece <=> fromPathPiece Either String Int" $ \(p::Either String Int) ->
+      case (fromPathPiece . toPathPiece) p of
+        Nothing -> False
+        Just pConverted -> p == pConverted
+
   describe "PathMultiPiece" $ do
     prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[String]) ->
       p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p


### PR DESCRIPTION
(Please see PR #22 for an alternative implementation.)

This PR adds a `PathPiece (Either a b)` instance.  Eithers are encoded like `Maybe`s with explicit constructors on routes.

For the following `config/routes`:

```
/maybe/Maybe Int
/either/Either String Int
```

the following paths are valid:

```
/maybe/Nothing
/maybe/Just 10
/either/Right 10
/either/Left something  # parsed as: Left "something"
```