### PR TITLE
Add PathPiece (Either a b) instance (alternative behaviour)

### DIFF
--- a/Web/PathPieces.hs
+++ b/Web/PathPieces.hs
@@ -181,6 +181,14 @@ instance (PathPiece a) => PathPiece (Maybe a) where
         Just s -> "Just " `S.append` toPathPiece s
         _ -> "Nothing"
 
+instance (PathPiece a, PathPiece b) => PathPiece (Either a b) where
+    fromPathPiece s = case fromPathPiece s of
+        (Just x) -> Just $ Right x
+        Nothing  -> case fromPathPiece s of
+                    (Just y) -> Just $ Left y
+                    Nothing  -> Nothing
+    toPathPiece = either toPathPiece toPathPiece
+
 -- | Instances of the 'PathMultiPiece' typeclass can be converted to and from
 --   several "path pieces" of URLs.
 --

--- a/test/main.hs
+++ b/test/main.hs
@@ -51,6 +51,9 @@ spec = do
       let p = Right i :: Either String Int
       in (fromPathPiece . toPathPiece) p == Just p
 
+    prop "toPathPiece <=> fromPathPiece Rights of Either Bool Int" $ \(p :: Either Bool Int) ->
+      (fromPathPiece . toPathPiece) p == Just p
+
   describe "PathMultiPiece" $ do
     prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[String]) ->
       p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p

--- a/test/main.hs
+++ b/test/main.hs
@@ -47,6 +47,10 @@ spec = do
         Nothing -> False
         Just pConverted -> p == pConverted
 
+    prop "toPathPiece <=> fromPathPiece Rights of Either String Int" $ \i ->
+      let p = Right i :: Either String Int
+      in (fromPathPiece . toPathPiece) p == Just p
+
   describe "PathMultiPiece" $ do
     prop "toPathMultiPiece <=> fromPathMultiPiece String" $ \(p::[String]) ->
       p == (fromJust . fromPathMultiPiece . toPathMultiPiece) p


### PR DESCRIPTION
(Please see PR #21 for an alternative implementation.)

This PR adds a `PathPiece (Either a b)` instance.  An alternative behaviour to #21 that is inconsistent with how `Maybe`s are _currently_ handled.

For the following `config/routes`:

```
/maybe/Maybe Int
/either/Either String Int
```

the following paths are valid:

```
/maybe/Nothing
/maybe/Just 10
/either/10              # parsed as: Right 10
/either/the-number-ten  # parsed as: Left "the-number-ten"
```

This one treats the `Either` on PathPiece as a way to fall back to an alternative type.  Example use case: I want an `Int`, or if not possible, a `String`.

Examples:

```
$ cabal repl path-pieces
> :set -XOverloadedStrings

> fromPathPiece "10" :: Maybe (Either String Int)
Just (Right 10)

> fromPathPiece "the-number-ten" :: Maybe (Either String Int)
Just (Left "the-number-ten")

> toPathPiece (Right 10 :: Either String Int)
"10"

> toPathPiece (Left "the-number-ten" :: Either String Int)
"the-number-ten"

> toPathPiece (Left 10 :: Either Int Int)
"10"
```


There are some caveats:

* The property `\(p :: Either a b) -> (fromPathPiece . toPathPiece) p == Just p` does not hold in general -- it does hold for `Right` values and types whose representations do not intersect among other specific cases;
* We can never parse to a `Left Int` with the `Either Int Int` type, as the only way for the "fallback" parse to be successful is for the first parse to have been successful first, which would cause the second parse not to happen;
* This is inconsistent with how maybes are handled: there the constructor `Just` is explictly marshalized.